### PR TITLE
Add OAuth2 Proxy support to Docusaurus Helm chart

### DIFF
--- a/charts/docusaurus/Chart.yaml
+++ b/charts/docusaurus/Chart.yaml
@@ -25,6 +25,10 @@ maintainers:
     url: https://github.com/akyriako
 dependencies:
   - name: oauth2-proxy
-    version: 7.12.6
+    version: 7.12.12
     repository: https://oauth2-proxy.github.io/manifests
     condition: oauth2-proxy.enabled
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 20.13.4
+    condition: redis.enabled

--- a/charts/docusaurus/Chart.yaml
+++ b/charts/docusaurus/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/akyriako
 dependencies:
   - name: oauth2-proxy
-    version: 7.12.5
+    version: 7.12.6
     repository: https://oauth2-proxy.github.io/manifests
     condition: oauth2-proxy.enabled

--- a/charts/docusaurus/Chart.yaml
+++ b/charts/docusaurus/Chart.yaml
@@ -23,3 +23,8 @@ maintainers:
   - name: akyriako
     email: kyriakos.akriotis@t-systems.com
     url: https://github.com/akyriako
+dependencies:
+  - name: oauth2-proxy
+    version: 7.12.5
+    repository: https://oauth2-proxy.github.io/manifests
+    condition: oauth2-proxy.enabled

--- a/charts/docusaurus/templates/clusterrolebinding-vault-tokenreview.yaml
+++ b/charts/docusaurus/templates/clusterrolebinding-vault-tokenreview.yaml
@@ -1,0 +1,21 @@
+{{- $oauthProxyValues := index .Values "oauth2-proxy" }}
+{{- if $oauthProxyValues.enabled }} 
+{{- if $oauthProxyValues.serviceAccount.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "docusaurus.fullname" . }}-vault-tokenreview-binding
+  labels:
+    {{- include "docusaurus.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ $oauthProxyValues.serviceAccount.name }}
+  namespace: {{ $oauthProxyValues.serviceAccount.namespace | default .Release.Namespace }}
+{{- else }}
+  {{- fail (printf "oauth2-proxy is enabled, but its ServiceAccount name (.Values.\"oauth2-proxy\".serviceAccount.name) is not set. Cannot create required ClusterRoleBinding for Vault TokenReview.") }}
+{{- end }}
+{{- end }}

--- a/charts/docusaurus/templates/deployment-docusaurus.yaml
+++ b/charts/docusaurus/templates/deployment-docusaurus.yaml
@@ -47,7 +47,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     cert-manager.io/cluster-issuer: {{ required "ingress.clusterIssuer is required" .Values.ingress.clusterIssuer }}
-    {{- if .Values.oauth2-proxy.enabled }}
+    {{- if index .Values "oauth2-proxy" "enabled" }}
     nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/oauth2/start?rd=$escaped_request_uri"
     {{- end }}

--- a/charts/docusaurus/templates/deployment-docusaurus.yaml
+++ b/charts/docusaurus/templates/deployment-docusaurus.yaml
@@ -43,24 +43,28 @@ kind: Ingress
 metadata:
   name: {{ include "docusaurus.fullname" . }}-docusaurus
   labels:
-  {{- include "docusaurus.labels" . | nindent 4 }}
+    {{- include "docusaurus.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     cert-manager.io/cluster-issuer: {{ required "ingress.clusterIssuer is required" .Values.ingress.clusterIssuer }}
+    {{- if .Values.oauth2-proxy.enabled }}
+    nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/oauth2/start?rd=$escaped_request_uri"
+    {{- end }}
 spec:
   ingressClassName: nginx
   tls:
-  - hosts:
-      - {{ required "ingress.host is required" .Values.ingress.host }}
-    secretName: {{ include "docusaurus.fullname" . }}-docusaurus-{{ required "ingress.clusterIssuer is required" .Values.ingress.clusterIssuer }}-certificate-tls
+    - hosts:
+        - {{ required "ingress.host is required" .Values.ingress.host }}
+      secretName: {{ include "docusaurus.fullname" . }}-docusaurus-{{ required "ingress.clusterIssuer is required" .Values.ingress.clusterIssuer }}-certificate-tls
   rules:
-  - host: {{ required "ingress.host is required" .Values.ingress.host }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: '{{ include "docusaurus.fullname" . }}-docusaurus'
-            port:
-              number: 80
-        path: /
-        pathType: ImplementationSpecific
+    - host: {{ required "ingress.host is required" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "docusaurus.fullname" . }}-docusaurus
+                port:
+                  number: 80

--- a/charts/docusaurus/templates/deployment-docusaurus.yaml
+++ b/charts/docusaurus/templates/deployment-docusaurus.yaml
@@ -38,6 +38,7 @@ spec:
     port: 80
     targetPort: 80
 ---
+{{- $oauthProxyValues := index .Values "oauth2-proxy" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -47,10 +48,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     cert-manager.io/cluster-issuer: {{ required "ingress.clusterIssuer is required" .Values.ingress.clusterIssuer }}
-    {{- if index .Values "oauth2-proxy" "enabled" }}
-    nginx.ingress.kubernetes.io/auth-url: "http://{{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/oauth2/start?rd=$escaped_request_uri"
-    {{- end }}
 spec:
   ingressClassName: nginx
   tls:
@@ -65,6 +62,10 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
+                {{- if $oauthProxyValues.enabled }}
+                name: {{ printf "%s-oauth2-proxy" .Release.Name | trunc 63 | trimSuffix "-" }}
+                {{- else }}
                 name: {{ include "docusaurus.fullname" . }}-docusaurus
+                {{- end }}
                 port:
                   number: 80

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -11,9 +11,7 @@ oauth2-proxy:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     tag: v7.8.1
   config:
-    clientID: "CLIENT_ID"
-    clientSecret: "CLIENT_SECRET"
-    cookieSecret: "COOKIE_SECRET"
+    existingSecret: ""
     configFile: |-
       provider = "oidc"
       oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
@@ -50,20 +48,3 @@ oauth2-proxy:
   metrics:
     serviceMonitor:
       enabled: true
-extraObjects: |
-  {{- if .Values.oauth2-proxy.serviceAccount.enabled }}
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: {{ include "oauth2-proxy.fullname" . }}-vault-tokenreview-binding
-      labels:
-        {{- include "oauth2-proxy.labels" . | nindent 4 }}
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:auth-delegator
-    subjects:
-    - kind: ServiceAccount
-      name: {{ .Values.oauth2-proxy.serviceAccount.name }}
-      namespace: {{ include "oauth2-proxy.namespace" . | default .Release.Namespace }}
-  {{- end }}

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -22,7 +22,7 @@ oauth2-proxy:
   podAnnotations:
     vault.hashicorp.com/auth-path: "auth/kubernetes_otcinfra1"
     vault.hashicorp.com/agent-inject: "true"
-    vault.hashicorp.com/agent-inject-secret-oauth-config: "secret/data/docs-next/stg"
+    vault.hashicorp.com/agent-inject-secret-oauth2-proxy.conf: "secret/data/docs-next/stg"
     vault.hashicorp.com/role: "docs-next"
     vault.hashicorp.com/agent-pid-file: "/home/vault/pidfile"
     vault.hashicorp.com/agent-inject-config-apiproxy: |
@@ -30,20 +30,21 @@ oauth2-proxy:
         use_auto_auth_token = "force"
         enforce_consistency = "always"
       }
-    vault.hashicorp.com/agent-inject-template-oauth-config: |
+    vault.hashicorp.com/agent-inject-template-secrets.sh: |
       {{`{{- with secret "secret/data/docs-next/stg" -}}`}}
       OAUTH2_PROXY_CLIENT_ID={{ .Data.data.client_id }}
       OAUTH2_PROXY_CLIENT_SECRET={{ .Data.data.client_secret }}
-      OAUTH2_PROXY_COOKIE_SECRET={{ .Data.data.cookie_secret }}
+      OAUTH2_PROXY_COOKIE_SECRET={{ .Data.data.client_cookie }}
       {{`{{- end }}`}}
   command:
     - /bin/sh
     - -c
     - |
-      source /vault/secrets/oauth-config
+      . /vault/secrets/secrets.sh &&
       exec /oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.conf
   serviceAccount:
     name: docusaurus-stg-oauth2-proxy
   metrics:
     serviceMonitor:
       enabled: true
+  proxyVarsAsSecrets: false

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -5,11 +5,21 @@ ingress:
   host:
   clusterIssuer: letsencrypt-prod
 
+redis:
+  enabled: true
+  architecture: standalone
+  master:
+    containerSecurityContext:
+      seccompProfile:
+        type: Unconfined
+  auth:
+   enabled: false
+
 oauth2-proxy:
   enabled: true
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.8.1
+    tag: v7.9.0
   podAnnotations:
     vault.hashicorp.com/auth-path: "auth/kubernetes_otcinfra1"
     vault.hashicorp.com/agent-inject: "true"
@@ -21,22 +31,35 @@ oauth2-proxy:
         enforce_consistency = "always"
       }
     vault.hashicorp.com/agent-inject-template-oauth-config.conf: |
-      provider = "oidc"
-      oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
-      redirect_url = "https://arch-stg.otc-service.com/oauth2/callback"
-      email_domains = ["*"]
-      upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
-      insecure_oidc_allow_unverified_email = true
-      whitelist_domains = "https://arch-stg.otc-service.com/"
-      cookie_domains = "https://arch-stg.otc-service.com/"
-      allowed_groups = ["/docs-next",]
-      {{- with secret "secret/data/docs-next/stg" }}
-      cookie_secret = "{{ .Data.data.client_cookie }}"
-      client_id = "{{ .Data.data.client_id }}"
-      client_secret = "{{ .Data.data.client_secret }}"
-      {{- end }}
+          provider = "oidc"
+          oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
+          redirect_url = "https://arch-stg.otc-service.com/oauth2/callback"
+          email_domains = ["*"]
+          upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
+          insecure_oidc_allow_unverified_email = true
+          cookie_domains = "arch-stg.otc-service.com"
+          allowed_roles = ["docusaurus-stg", "docs-next"]
+          cookie_secure = true
+          cookie_httponly = true
+          cookie_samesite = "lax"
+          session_store_type = "redis"
+          redis_connection_url = "redis://docusaurus-stg-redis-headless:6379"
+          show_debug_on_error = true
+          set_authorization_header = true
+          request_logging = true
+          auth_logging = true
+          standard_logging = true
+          skip_provider_button = true
+          oidc_groups_claim = "resource_access.docusaurus-stg.roles"
+          scope = "openid email profile"
+          pass_access_token = true
+          {{- with secret "secret/data/docs-next/stg" }}
+          cookie_secret = "{{ .Data.data.client_cookie }}"
+          client_id = "{{ .Data.data.client_id }}"
+          client_secret = "{{ .Data.data.client_secret }}"
+          {{- end }}
   extraArgs:
-    - --config=/vault/secrets/oauth-config.conf
+    - '--config=/vault/secrets/oauth-config.conf'
   serviceAccount:
     name: docusaurus-stg-oauth2-proxy
   metrics:

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -4,3 +4,39 @@ tag: 20250221.28.0-fa7594f
 ingress:
   host:
   clusterIssuer: letsencrypt-prod
+
+oauth2-proxy:
+  enabled: true
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: v7.5.1
+  config:
+    clientID: "CLIENT_ID"
+    clientSecret: "CLIENT_SECRET"
+    cookieSecret: "COOKIE_SECRET"
+    configFile: |-
+      provider = "oidc"
+      oidc_issuer_url = "https://"
+      redirect_url = "https://{{ .Values.ingress.host }}/oauth2/callback"
+      email_domains = ["*"]
+      upstreams = ["file:///dev/null"]
+      whitelist_domains = "{{ .Values.ingress.host }}"
+      cookie_domains = "{{ .Values.ingress.host }}"
+  podAnnotations:
+    vault.hashicorp.com/agent-inject: "true"
+    vault.hashicorp.com/agent-inject-secret-oauth-config: "secret/data/path/to/oauth"
+    vault.hashicorp.com/role: "docs-next"
+    vault.hashicorp.com/agent-inject-template-oauth-config: |
+      {{`{{- with secret "secret/data/path/to/oauth" -}}`}}
+      OAUTH2_PROXY_CLIENT_ID={{ .Data.data.client_id }}
+      OAUTH2_PROXY_CLIENT_SECRET={{ .Data.data.client_secret }}
+      OAUTH2_PROXY_COOKIE_SECRET={{ .Data.data.cookie_secret }}
+      {{`{{- end }}`}}
+  extraArgs:
+    - --config=/etc/oauth2-proxy/oauth2-proxy.conf
+  command:
+    - /bin/sh
+    - -c
+    - |
+      source /vault/secrets/oauth-config
+      exec /oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.conf

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -9,31 +9,29 @@ oauth2-proxy:
   enabled: true
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.5.1
+    tag: v7.8.1
   config:
     clientID: "CLIENT_ID"
     clientSecret: "CLIENT_SECRET"
     cookieSecret: "COOKIE_SECRET"
     configFile: |-
       provider = "oidc"
-      oidc_issuer_url = "https://"
-      redirect_url = "https://{{ .Values.ingress.host }}/oauth2/callback"
+      oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
+      redirect_url = "https://{{ .Values.ingress.host }}"
       email_domains = ["*"]
       upstreams = ["file:///dev/null"]
       whitelist_domains = "{{ .Values.ingress.host }}"
       cookie_domains = "{{ .Values.ingress.host }}"
   podAnnotations:
     vault.hashicorp.com/agent-inject: "true"
-    vault.hashicorp.com/agent-inject-secret-oauth-config: "secret/data/path/to/oauth"
+    vault.hashicorp.com/agent-inject-secret-oauth-config: "secret/data/docs-next/stg"
     vault.hashicorp.com/role: "docs-next"
     vault.hashicorp.com/agent-inject-template-oauth-config: |
-      {{`{{- with secret "secret/data/path/to/oauth" -}}`}}
+      {{`{{- with secret "secret/data/docs-next/stg" -}}`}}
       OAUTH2_PROXY_CLIENT_ID={{ .Data.data.client_id }}
       OAUTH2_PROXY_CLIENT_SECRET={{ .Data.data.client_secret }}
       OAUTH2_PROXY_COOKIE_SECRET={{ .Data.data.cookie_secret }}
       {{`{{- end }}`}}
-  extraArgs:
-    - --config=/etc/oauth2-proxy/oauth2-proxy.conf
   command:
     - /bin/sh
     - -c

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -17,8 +17,10 @@ oauth2-proxy:
       redirect_url = "https://{{ .Values.ingress.host }}"
       email_domains = ["*"]
       upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
+      insecure_oidc_allow_unverified_email = true
       whitelist_domains = "{{ .Values.ingress.host }}"
       cookie_domains = "{{ .Values.ingress.host }}"
+      allowed_groups = ["/docs-next",]
   podAnnotations:
     vault.hashicorp.com/auth-path: "auth/kubernetes_otcinfra1"
     vault.hashicorp.com/agent-inject: "true"

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -23,9 +23,16 @@ oauth2-proxy:
       whitelist_domains = "{{ .Values.ingress.host }}"
       cookie_domains = "{{ .Values.ingress.host }}"
   podAnnotations:
+    vault.hashicorp.com/auth-path: "auth/kubernetes_otcinfra1"
     vault.hashicorp.com/agent-inject: "true"
     vault.hashicorp.com/agent-inject-secret-oauth-config: "secret/data/docs-next/stg"
     vault.hashicorp.com/role: "docs-next"
+    vault.hashicorp.com/agent-pid-file: "/home/vault/pidfile"
+    vault.hashicorp.com/agent-inject-config-apiproxy: |
+      api_proxy {
+        use_auto_auth_token = "force"
+        enforce_consistency = "always"
+      }
     vault.hashicorp.com/agent-inject-template-oauth-config: |
       {{`{{- with secret "secret/data/docs-next/stg" -}}`}}
       OAUTH2_PROXY_CLIENT_ID={{ .Data.data.client_id }}

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -11,7 +11,6 @@ oauth2-proxy:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     tag: v7.8.1
   config:
-    existingSecret: ""
     configFile: |-
       provider = "oidc"
       oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -10,21 +10,9 @@ oauth2-proxy:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     tag: v7.8.1
-  config:
-    configFile: |-
-      provider = "oidc"
-      oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
-      redirect_url = "https://{{ .Values.ingress.host }}"
-      email_domains = ["*"]
-      upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
-      insecure_oidc_allow_unverified_email = true
-      whitelist_domains = "{{ .Values.ingress.host }}"
-      cookie_domains = "{{ .Values.ingress.host }}"
-      allowed_groups = ["/docs-next",]
   podAnnotations:
     vault.hashicorp.com/auth-path: "auth/kubernetes_otcinfra1"
     vault.hashicorp.com/agent-inject: "true"
-    vault.hashicorp.com/agent-inject-secret-oauth2-proxy.conf: "secret/data/docs-next/stg"
     vault.hashicorp.com/role: "docs-next"
     vault.hashicorp.com/agent-pid-file: "/home/vault/pidfile"
     vault.hashicorp.com/agent-inject-config-apiproxy: |
@@ -32,21 +20,28 @@ oauth2-proxy:
         use_auto_auth_token = "force"
         enforce_consistency = "always"
       }
-    vault.hashicorp.com/agent-inject-template-secrets.sh: |
-      {{`{{- with secret "secret/data/docs-next/stg" -}}`}}
-      OAUTH2_PROXY_CLIENT_ID={{ .Data.data.client_id }}
-      OAUTH2_PROXY_CLIENT_SECRET={{ .Data.data.client_secret }}
-      OAUTH2_PROXY_COOKIE_SECRET={{ .Data.data.client_cookie }}
-      {{`{{- end }}`}}
-  command:
-    - /bin/sh
-    - -c
-    - |
-      . /vault/secrets/secrets.sh &&
-      exec /oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.conf
+    vault.hashicorp.com/agent-inject-template-oauth-config.conf: |
+      provider = "oidc"
+      oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
+      redirect_url = "https://arch-stg.otc-service.com/oauth2/callback"
+      email_domains = ["*"]
+      upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
+      insecure_oidc_allow_unverified_email = true
+      whitelist_domains = "https://arch-stg.otc-service.com/"
+      cookie_domains = "https://arch-stg.otc-service.com/"
+      allowed_groups = ["/docs-next",]
+      {{- with secret "secret/data/docs-next/stg" }}
+      cookie_secret = "{{ .Data.data.client_cookie }}"
+      client_id = "{{ .Data.data.client_id }}"
+      client_secret = "{{ .Data.data.client_secret }}"
+      {{- end }}
+  extraArgs:
+    - --config=/vault/secrets/oauth-config.conf
   serviceAccount:
     name: docusaurus-stg-oauth2-proxy
   metrics:
     serviceMonitor:
       enabled: true
   proxyVarsAsSecrets: false
+  config:
+    configFile: ""

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -16,7 +16,7 @@ oauth2-proxy:
       oidc_issuer_url = "https://keycloak.eco.tsi-dev.otc-service.com/realms/eco"
       redirect_url = "https://{{ .Values.ingress.host }}"
       email_domains = ["*"]
-      upstreams = ["file:///dev/null"]
+      upstreams = ["http://docusaurus-stg-docs-next-docusaurus"]
       whitelist_domains = "{{ .Values.ingress.host }}"
       cookie_domains = "{{ .Values.ingress.host }}"
   podAnnotations:

--- a/charts/docusaurus/values-stg.yaml
+++ b/charts/docusaurus/values-stg.yaml
@@ -45,3 +45,25 @@ oauth2-proxy:
     - |
       source /vault/secrets/oauth-config
       exec /oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.conf
+  serviceAccount:
+    name: docusaurus-stg-oauth2-proxy
+  metrics:
+    serviceMonitor:
+      enabled: true
+extraObjects: |
+  {{- if .Values.oauth2-proxy.serviceAccount.enabled }}
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: {{ include "oauth2-proxy.fullname" . }}-vault-tokenreview-binding
+      labels:
+        {{- include "oauth2-proxy.labels" . | nindent 4 }}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: {{ .Values.oauth2-proxy.serviceAccount.name }}
+      namespace: {{ include "oauth2-proxy.namespace" . | default .Release.Namespace }}
+  {{- end }}


### PR DESCRIPTION
- Update Chart.yaml to include oauth2-proxy dependency
- Configure OAuth2 Proxy in values-stg.yaml with OIDC provider settings and redis session storage
- Modify ingress template to add authentication annotations when OAuth2 Proxy is enabled
- Integrate Vault secret injection for OAuth configuration